### PR TITLE
Corrected order of jm_enabledb

### DIFF
--- a/JMConfigRanked.cfg
+++ b/JMConfigRanked.cfg
@@ -21,9 +21,9 @@ compat_skulltagjumping 1
 
 // Jumpmaze settings
 set jm_countdown 1
-set jm_enabledb 1
 authhostname auth.zandronum.com:16666 //use any auth you'd like here!
 databasefile jumpmazeDB //use any DB name you'd like here
+set jm_enabledb 1
 db_enable_wal // Enable SQLite write-ahead logging
 
 // Clear and re-define the maplist


### PR DESCRIPTION
The leaderboard is not enabled in jumpmaze if jm_enabledb is placed before the database commands.